### PR TITLE
Fix deploy signing properties

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,8 @@ on:
 env:
   ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
   ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
-  ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-  ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+  ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+  ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
 
 jobs:
   deploy-linux:


### PR DESCRIPTION
## Summary

- Update deploy workflow Gradle signing property names for the Vanniktech Maven Publish plugin.
- Keep existing GitHub secret names unchanged.

## Context

The deploy workflow failed at `:signMavenPublication` with `no configured signatory`. The workflow was exporting the old `signingKey` / `signingPassword` Gradle properties, while the current publishing plugin reads `signingInMemoryKey` / `signingInMemoryKeyPassword` for in-memory signing.

## Validation

- Not run locally because the publishing signing secrets are only available in GitHub Actions.
