### PR TITLE
Fix Maven Central deploy credentials

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@ on:
   workflow_dispatch:
 
 env:
-  ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-  ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
+  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
   ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
   ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
 


### PR DESCRIPTION
## Summary

- Update deploy workflow Maven Central credential Gradle property names for the Vanniktech Maven Publish plugin.
- Keep existing GitHub secret names unchanged.

## Context

After fixing signing properties, deploy reached `publishMavenPublicationToMavenCentralRepository` and failed while stopping `maven-central-build-service` because the plugin could not read a required property. The plugin reads `mavenCentralUsername` and `mavenCentralPassword`, while the workflow was still exporting `sonatypeUsername` and `sonatypePassword`.

## Validation

- Confirmed the property names from `gradle-maven-publish-plugin-0.35.0`.
